### PR TITLE
adds gcloud-auth script to easily set an active account

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN ssh-keygen -t dsa -b 1024 -N "" -f /root/.ssh/google_compute_engine
 
 ENV CLOUDSDK_PYTHON_SITEPACKAGES 1
 ADD activate-service-accounts /root/
+COPY gcloud-auth /usr/local/bin/
 
 ONBUILD ADD projects/* /root/project-keys/
 ONBUILD RUN /root/activate-service-accounts

--- a/gcloud-auth
+++ b/gcloud-auth
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+project=$1
+if [ -z "$project" ]; then
+    echo "Usage: gcloud-auth <project-name>"
+    exit 1
+fi
+
+account=""
+if [ -d /root/project-keys ] ; then
+    for key_file in `find /root/project-keys -type f -name \*.account`; do
+        filename="${key_file##*/}"
+        if [ "$project" == "${filename%.*}" ] ; then
+            account=`cat ${key_file}`
+        fi
+    done
+fi
+if [ -z "$account" ]; then
+    echo "Account file '${project}.account' not found"
+    exit 1
+fi
+
+gcloud config set account "${account}" && echo "Account for '${project}' is now active"
+
+

--- a/gcloud-auth
+++ b/gcloud-auth
@@ -20,6 +20,6 @@ if [ -z "$account" ]; then
     exit 1
 fi
 
-gcloud config set account "${account}" && echo "Account for '${project}' is now active"
+gcloud config set account "${account}"
 
 


### PR DESCRIPTION
Because gcloud can only have 1 account active at a time and because the account's email is not user friendly, let's provide a binary to easily set an active account using the project name instead of the account email.
